### PR TITLE
Switching this to send a message to nodecg-tiltify

### DIFF
--- a/graphics/index.html
+++ b/graphics/index.html
@@ -49,7 +49,7 @@
                         continue;
                     }
                     alert.notify(`${newvalue[i].name} Donated $${newvalue[i].amount}`, newvalue[i]);
-                    newvalue[i].shown = true
+                    nodecg.sendMessageToBundle('mark-donation-as-shown', 'nodecg-tiltify', newvalue[i]);
                 }
 
             });


### PR DESCRIPTION
This will allow the extension itself to mark things as shown instead of doing
any manipulation in the nodecg-tiltify-donation-alert package
